### PR TITLE
Sync with mdformat 0.7.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.4.0
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
@@ -8,11 +8,11 @@ repos:
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.6.0
+  rev: v1.8.0
   hooks:
   - id: python-check-blanket-noqa
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.5.3
+  rev: 5.8.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
@@ -20,10 +20,10 @@ repos:
   hooks:
   - id: black
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.9.0
   hooks:
   - id: flake8
     additional_dependencies:
-    - flake8-bugbear==20.1.4
+    - flake8-bugbear==21.4.3
     - flake8-builtins==1.5.3
-    - flake8-comprehensions==3.2.3
+    - flake8-comprehensions==3.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
-  - id: trailing-whitespace
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks

--- a/.pre-commit-test.yaml
+++ b/.pre-commit-test.yaml
@@ -1,11 +1,12 @@
+# A pre-commit hook for testing unreleased changes.
+# This is a system hook that will NOT be given a virtual environment.
+# Thus you will need to `pip install .` before running.
 repos:
   - repo: local
     hooks:
     - id: mdformat
-      name: mdformat
+      name: mdformat-no-venv
       entry: mdformat
       files: "tests/pre-commit-test.md"
       types: [markdown]
-      language: python
-      additional_dependencies:
-        - mdformat_footnote
+      language: system

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Executable Books
+Copyright (c) 2020 Gaige B. Paulsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov.io][cov-badge]][cov-link]
 [![PyPI version][pypi-badge]][pypi-link]
 
-An [mdformat](https://github.com/executablebooks/mdformat) plugin for...
+Footnote format addition for [mdformat](https://github.com/executablebooks/mdformat).
 
 ## Development
 

--- a/mdformat_footnote/__init__.py
+++ b/mdformat_footnote/__init__.py
@@ -1,5 +1,5 @@
 """An mdformat plugin for parsing/validating footnotes"""
 
-from .plugin import render_token, update_mdit  # noqa: F401
+from .plugin import RENDERER_FUNCS, update_mdit  # noqa: F401
 
 __version__ = "0.0.4"

--- a/mdformat_footnote/__init__.py
+++ b/mdformat_footnote/__init__.py
@@ -1,5 +1,5 @@
 """An mdformat plugin for parsing/validating footnotes"""
 
-from .plugin import RENDERER_FUNCS, update_mdit  # noqa: F401
-
 __version__ = "0.0.4"
+
+from .plugin import RENDERERS, update_mdit  # noqa: F401

--- a/mdformat_footnote/plugin.py
+++ b/mdformat_footnote/plugin.py
@@ -1,8 +1,8 @@
-from typing import Mapping, MutableMapping
+from typing import Mapping
 
 from markdown_it import MarkdownIt
-from mdformat.renderer import RenderTreeNode
-from mdformat.renderer.typing import RendererFunc
+from mdformat.renderer import RenderContext, RenderTreeNode
+from mdformat.renderer.typing import Render
 from mdit_py_plugins.footnote import footnote_plugin
 
 
@@ -14,45 +14,28 @@ def update_mdit(mdit: MarkdownIt) -> None:
     mdit.disable("footnote_inline")
 
 
-def _footnote_ref_renderer(
-    node: RenderTreeNode,
-    renderer_funcs: Mapping[str, RendererFunc],
-    options: Mapping,
-    env: MutableMapping,
-) -> str:
+def _footnote_ref_renderer(node: RenderTreeNode, context: RenderContext) -> str:
     return f"[^{node.meta['label']}]"
 
 
-def _footnote_renderer(
-    node: RenderTreeNode,
-    renderer_funcs: Mapping[str, RendererFunc],
-    options: Mapping,
-    env: MutableMapping,
-) -> str:
+def _footnote_renderer(node: RenderTreeNode, context: RenderContext) -> str:
     text = f"[^{node.meta['label']}]: "
     child_iterator = iter(node.children)
     first_child = next(child_iterator)
     if first_child.type == "footnote_anchor":
         return text
     else:
-        text += first_child.render(renderer_funcs, options, env)
+        text += first_child.render(context)
     for child in child_iterator:
-        text += "\n\n    " + child.render(renderer_funcs, options, env)
+        text += "\n\n    " + child.render(context)
     return text
 
 
-def _render_children(
-    node: RenderTreeNode,
-    renderer_funcs: Mapping[str, RendererFunc],
-    options: Mapping,
-    env: MutableMapping,
-) -> str:
-    return "\n\n".join(
-        child.render(renderer_funcs, options, env) for child in node.children
-    )
+def _render_children(node: RenderTreeNode, context: RenderContext) -> str:
+    return "\n\n".join(child.render(context) for child in node.children)
 
 
-RENDERER_FUNCS: Mapping[str, RendererFunc] = {
+RENDERERS: Mapping[str, Render] = {
     "footnote": _footnote_renderer,
     "footnote_ref": _footnote_ref_renderer,
     "footnote_block": _render_children,

--- a/mdformat_footnote/plugin.py
+++ b/mdformat_footnote/plugin.py
@@ -9,6 +9,9 @@ from mdit_py_plugins.footnote import footnote_plugin
 def update_mdit(mdit: MarkdownIt) -> None:
     """Update the parser, adding the footnote plugin."""
     mdit.use(footnote_plugin)
+    # Disable inline footnotes for now, since we don't have rendering
+    # support for them yet.
+    mdit.disable("footnote_inline")
 
 
 def _footnote_ref_renderer(

--- a/mdformat_footnote/plugin.py
+++ b/mdformat_footnote/plugin.py
@@ -26,9 +26,16 @@ def _footnote_renderer(
     options: Mapping,
     env: MutableMapping,
 ) -> str:
-    return f"[^{node.meta['label']}]: " + _render_children(
-        node, renderer_funcs, options, env, separator=""
-    )
+    text = f"[^{node.meta['label']}]: "
+    child_iterator = iter(node.children)
+    first_child = next(child_iterator)
+    if first_child.type == "footnote_anchor":
+        return text
+    else:
+        text += first_child.render(renderer_funcs, options, env)
+    for child in child_iterator:
+        text += "\n\n    " + child.render(renderer_funcs, options, env)
+    return text
 
 
 def _render_children(

--- a/mdformat_footnote/plugin.py
+++ b/mdformat_footnote/plugin.py
@@ -43,10 +43,8 @@ def _render_children(
     renderer_funcs: Mapping[str, RendererFunc],
     options: Mapping,
     env: MutableMapping,
-    *,
-    separator: str = "\n\n",
 ) -> str:
-    return separator.join(
+    return "\n\n".join(
         child.render(renderer_funcs, options, env) for child in node.children
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 keywords = "mdformat,markdown,markdown-it"
 
 requires-python=">=3.6"
-requires=["mdformat >=0.6.0,<0.7.0",
+requires=["mdformat >=0.7.0,<0.8.0",
           "mdit-py-plugins",
             ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 keywords = "mdformat,markdown,markdown-it"
 
 requires-python=">=3.6"
-requires=["mdformat >=0.5.3,<0.6.0",
+requires=["mdformat >=0.6.0,<0.7.0",
           "mdit-py-plugins",
             ]
 
@@ -37,7 +37,6 @@ include = []
 exclude = [".github/", "tests/"]
 
 [tool.isort]
-skip = ["venv"]
 # Force imports to be sorted by module, independent of import type
 force_sort_within_sections = true
 # Group first party and local folder imports together

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flit
 tox
 pytest
-mdformat >=0.5.3,<0.6.0
+mdformat >=0.7.0,<0.8.0
 mdit_py_plugins

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -29,8 +29,11 @@ Test Footnotes
 Here is a footnote reference,[^1] and another.[^longnote]
 [^1]: Here is the footnote.
 [^longnote]: Here's one with multiple blocks.
+
     Subsequent paragraphs are indented to show that they
 belong to the previous footnote.
+
+    Third paragraph here.
 .
 # Now some markdown
 
@@ -39,6 +42,20 @@ Here is a footnote reference,[^1] and another.[^longnote]
 [^1]: Here is the footnote.
 
 [^longnote]: Here's one with multiple blocks.
-Subsequent paragraphs are indented to show that they
+
+    Subsequent paragraphs are indented to show that they
 belong to the previous footnote.
+
+    Third paragraph here.
+.
+
+Empty footnote
+.
+Here is a footnote reference [^emptynote]
+
+[^emptynote]: 
+.
+Here is a footnote reference [^emptynote]
+
+[^emptynote]: 
 .

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -7,6 +7,7 @@ This is the input Markdown test,
 then below add the expected output.
 .
 
+
 another test
 .
 Some *markdown*
@@ -22,6 +23,7 @@ Some *markdown*
 
 * c
 .
+
 
 Test Footnotes
 .
@@ -49,6 +51,7 @@ belong to the previous footnote.
     Third paragraph here.
 .
 
+
 Empty footnote
 .
 Here is a footnote reference [^emptynote]
@@ -58,4 +61,25 @@ Here is a footnote reference [^emptynote]
 Here is a footnote reference [^emptynote]
 
 [^emptynote]: 
+.
+
+
+Move footnote definitions to the end (but before link ref defs)
+.
+[link]: https://www.python.org
+[^1]: Here is the footnote.
+
+# Now we reference them
+Here is a footnote reference[^1]
+Here is a [link]
+
+.
+# Now we reference them
+
+Here is a footnote reference[^1]
+Here is a [link]
+
+[^1]: Here is the footnote.
+
+[link]: https://www.python.org
 .

--- a/tests/pre-commit-test.md
+++ b/tests/pre-commit-test.md
@@ -2,4 +2,4 @@
 
 This was a test[^1].
 
-[^1] Here you go
+[^1]: Here you go

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from markdown_it.utils import read_fixture_file
-from mdformat import text as render_text
+import mdformat
 import pytest
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures.md"
@@ -12,6 +12,6 @@ fixtures = read_fixture_file(FIXTURE_PATH)
     "line,title,text,expected", fixtures, ids=[f[1] for f in fixtures]
 )
 def test_fixtures(line, title, text, expected):
-    output = render_text(text, extensions={"footnote"})
+    output = mdformat.text(text, extensions={"footnote"})
     print(output)
     assert output.rstrip() == expected.rstrip(), output


### PR DESCRIPTION
- Sync with updated plugin API in mdformat version 0.7.x
- Fix rendering of multi-paragraph footnotes
- Remove `trailing-whitespace` pre-commit hook, because trailing space is needed to denote a footnote with no content
- Disable inline footnote parsing because we don't have renderer support for them yet