### PR TITLE
⬆️ UPGRADE: Support mdformat v1 and Python >=3.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,25 +13,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
-    - uses: pre-commit/action@v2.0.0
+        python-version: '3.10'
+    - uses: pre-commit/action@v3.0.0
 
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.10', '3.13']
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -39,7 +39,7 @@ jobs:
       # we install with flit --pth-file,
       # so that coverage will be recorded for the module
       run: |
-        pip install flit
+        pip install flit>=3.12.0
         flit install --deps=production --extras=test --pth-file
 
     - name: Run pytest
@@ -47,10 +47,10 @@ jobs:
         pytest --cov=mdformat_footnote --cov-report=xml --cov-report=term-missing
 
  #   - name: Upload to Codecov
- #     if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
+ #     if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.10
  #     uses: codecov/codecov-action@v1
  #     with:
- #       name: pytests-py3.7
+ #       name: pytests-py3.10
  #       flags: pytests
  #       file: ./coverage.xml
  #       fail_ci_if_error: true
@@ -59,11 +59,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: '3.10'
 
     - name: Installation (deps and package)
       run: |
@@ -81,14 +81,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/checkout@v4
+    - name: Set up Python 3
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: '3.x'
     - name: install flit
       run: |
-        pip install flit~=3.0
+        pip install flit>=3.12.0
     - name: Build and publish
       run: |
         flit publish

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.8.0
+  rev: v1.10.0
   hooks:
   - id: python-check-blanket-noqa
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.8.0
+  rev: 7.0.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 25.9.0
   hooks:
   - id: black
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.0
+- repo: https://github.com/pycqa/flake8
+  rev: 7.3.0
   hooks:
   - id: flake8
     additional_dependencies:
-    - flake8-bugbear==21.4.3
-    - flake8-builtins==1.5.3
-    - flake8-comprehensions==3.4.0
+    - flake8-bugbear>=24.12.12
+    - flake8-builtins>=3.0.0
+    - flake8-comprehensions>=3.17.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ tox
 and with test coverage:
 
 ```bash
-tox -e py39-cov
+tox -e py310-cov
 ```
 
 The easiest way to write tests, is to edit tests/fixtures.md
@@ -33,7 +33,7 @@ The easiest way to write tests, is to edit tests/fixtures.md
 To run the code formatting and style checks:
 
 ```bash
-tox -e py39-pre-commit
+tox -e py310-pre-commit
 ```
 
 or directly
@@ -46,7 +46,7 @@ pre-commit run --all
 To run the pre-commit hook test:
 
 ```bash
-tox -e py39-hook
+tox -e py310-hook
 ```
 
 ## Publish to PyPi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,16 +18,15 @@ classifiers = [
 ]
 keywords = "mdformat,markdown,markdown-it"
 
-requires-python=">=3.7"
-requires=["mdformat >=0.7.8,<0.8.0",
-          "mdit-py-plugins",
+requires-python=">=3.10"
+requires=["mdformat >=0.7.0",
+          "mdit-py-plugins >=0.4.0",
             ]
 
 [tool.flit.metadata.requires-extra]
 test = [
-    "pytest~=6.0",
-    "coverage",
-    "pytest-cov",
+    "pytest>=8.0.0",
+    "pytest-cov>=7.0.0",
 ]
 dev = ["pre-commit"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-flit
-tox
-pytest
-mdformat >=0.7.0,<0.8.0
-mdit_py_plugins
+flit>=3.12.0
+tox>=4.31.0
+pytest>=8.0.0
+mdformat >=0.7.0
+mdit_py_plugins >=0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
-envlist = py{37,38,39,310}
+envlist = py{310,313}
 isolated_build = True
 
-[testenv:py{37,38,39,310}]
+[testenv:py{310,313}]
 extras = test
 commands = pytest {posargs}
 
-[testenv:py{37,38,39,310}-cov]
+[testenv:py{310,313}-cov]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/mdformat_footnote {posargs}
 
-[testenv:py{37,38,39,310}-pre-commit]
+[testenv:py{310,313}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs}
 
-[testenv:py{37,38,39,310}-hook]
+[testenv:py{310,313}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 


### PR DESCRIPTION
Closes: #12 

- Drop Python 3.7, 3.8, and 3.9
- Support mdformat v1
- Includes some much needed updates that overlap with #9