### PR TITLE
Revise PyPi publishing instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,10 @@ tox -e py310-hook
 
 ## Publish to PyPi
 
-Either use flit directly:
+Publishing is handled using a trusted action as part of the release process. Authetication is via OIDC
+and should be triggered through by creating a release with a tag equal to the version, e.g. `v0.0.1`.
 
-```bash
-pip install flit
-flit publish
-```
-
-or trigger the GitHub Action job, by creating a release with a tag equal to the version, e.g. `v0.0.1`.
-
-Note, this requires generating an API key on PyPi and adding it to the repository `Settings/Secrets`, under the name `PYPI_KEY`.
+Maintainer note: this is configured in PyPi as a trusted repository.
 
 [ci-badge]: https://github.com/gaige/mdformat-footnote/workflows/CI/badge.svg?branch=master
 [ci-link]: https://github.com/gaige/mdformat-footnote/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ tox -e py310-hook
 Publishing is handled using a trusted action as part of the release process. Authetication is via OIDC
 and should be triggered through by creating a release with a tag equal to the version, e.g. `v0.0.1`.
 
-Maintainer note: this is configured in PyPi as a trusted repository.
+Maintainer note: this is configured in PyPI as a trusted repository.
 
 [ci-badge]: https://github.com/gaige/mdformat-footnote/workflows/CI/badge.svg?branch=master
 [ci-link]: https://github.com/gaige/mdformat-footnote/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ tox -e py310-hook
 ## Publish to PyPi
 
 Publishing is handled using a trusted action as part of the release process. Authetication is via OIDC
-and should be triggered through by creating a release with a tag equal to the version, e.g. `v0.0.1`.
+and should be triggered by creating a release with a tag equal to the version, e.g. `v0.0.1`.
 
 Maintainer note: this is configured in PyPI as a trusted repository.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ tox -e py310-hook
 
 ## Publish to PyPi
 
-Publishing is handled using a trusted action as part of the release process. Authetication is via OIDC
+Publishing is handled using a trusted action as part of the release process. Authentication is via OIDC
 and should be triggered by creating a release with a tag equal to the version, e.g. `v0.0.1`.
 
 Maintainer note: this is configured in PyPI as a trusted repository.


### PR DESCRIPTION
Updated the publishing instructions for PyPi to clarify the use of GitHub Actions and OIDC authentication.