### PR TITLE
🔧 MAINTAIN: keep GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-dependencies:
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: startsWith(github.ref, 'refs/tags/v')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest
@@ -118,6 +118,7 @@ jobs:
     name: >-
       Sign the Python 🐍 distribution 📦 with Sigstore
       and upload them to GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest
@@ -133,12 +134,11 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
         with:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
-          upload-signing-artifacts: 'false'
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,10 +83,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Upgrade Pip
-        run: python -m pip install --upgrade pip
-      - name: Install Poetry
-        run: python -m pip install build
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
@@ -135,11 +133,12 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
+          upload-signing-artifacts: 'false'
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Attempt to address CI failure: https://github.com/executablebooks/mdformat-footnote/actions/runs/18628585373/job/53110081204 and add Dependabot to keep Actions up to date in the future

```
Current runner version: '2.328.0'
Runner Image Provisioner
Operating System
Runner Image
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/download-artifact@v4' (SHA:d3f86a106a0bac45b974a628896c90dbdf5c8093)
Download action repository 'sigstore/gh-action-sigstore-python@v2.1.1' (SHA:61f6a500bbfdd9a2a339cf033e5421951fbc1cd2)
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

